### PR TITLE
Remove CSRF check for DRF requests

### DIFF
--- a/accounts/authentications.py
+++ b/accounts/authentications.py
@@ -1,0 +1,6 @@
+from rest_framework.authentication import SessionAuthentication
+
+
+class CsrfExemptSessionAuthentication(SessionAuthentication):
+    def enforce_csrf(self, request):
+        return  # To not perform the csrf check previously happening

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -216,7 +216,7 @@ class UserCreateToken(APITestCase):
         UserProfileFactory(**user_data)
         url = reverse("user_profile_api")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
 
     def test_get_account_info_authenticated(self):
         user_data = {"email": "test@example.com", "password": "test"}
@@ -252,7 +252,7 @@ class UserCreateToken(APITestCase):
         self.client.post(logout_url)
 
         response = self.client.get(profile_url)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
 
 
 class UserProfileTest(APITestCase):

--- a/settings/base.py
+++ b/settings/base.py
@@ -89,8 +89,7 @@ WSGI_APPLICATION = "guppy.wsgi.application"
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
+        "accounts.authentications.CsrfExemptSessionAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": (
         "rest_framework.permissions.IsAuthenticated",


### PR DESCRIPTION
Hi @YPCrumble, this PR is used for removing CSRF validate for DRF requests.

Please help me to review.