### PR TITLE
Remove CKEDITOR_JQUERY_URL

### DIFF
--- a/faqs/templates/faqs/faq_list.html
+++ b/faqs/templates/faqs/faq_list.html
@@ -40,7 +40,7 @@
   // TODO: try to apply this solution: https://docs.djangoproject.com/en/2.1/ref/templates/builtins/#for
   $(document).ready(function() {
     $('.list-faq .item:first .title').addClass('active')
-    $( '.list-faq .item .title' ).click(function() {
+    $('.list-faq .item .title').click(function() {
       $(this).siblings('.description').stop().slideToggle()
       $(this).toggleClass('active')
     });

--- a/settings/base.py
+++ b/settings/base.py
@@ -155,10 +155,6 @@ CELERY_TASK_SOFT_TIME_LIMIT = 60
 CELERY_RESULT_BACKEND = "django-db"
 
 # CKEditor
-CKEDITOR_JQUERY_URL = (
-    "https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"
-)
-
 CKEDITOR_UPLOAD_PATH = "uploads/"
 
 CKEDITOR_CONFIGS = {


### PR DESCRIPTION
Hi @YPCrumble, this PR is used for removing `CKEDITOR_JQUERY_URL` (https://django-ckeditor.readthedocs.io/en/latest/#id2).
Please help me to review.