### PR TITLE
Change logging handle to file

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -154,9 +154,16 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "formatter": "simple",
         },
+        "file": {
+            "filters": ["require_debug_false"],
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": "bookclubz.log",
+            "formatter": "simple",
+            "maxBytes": 1024 * 1024 * 50,
+        },
     },
     "root": {
-        "handlers": ["console"],
+        "handlers": ["file"],
         "level": "INFO",
     },
 }


### PR DESCRIPTION
Hi @truonghn @YPCrumble, this PR is used for changing the logging handle to `file` to work with LogDNA.
Please help me to review.